### PR TITLE
Alena/class chat class user manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,6 @@ frontend:
 	cd frontend; npm run compile; npm run serve
 
 
-backend-test:
-	cd backend; npm run backend-test
+backend-tests:
+	cd backend; npm run backend-tests
 

--- a/backend/src/lib/Class/Chat.ts
+++ b/backend/src/lib/Class/Chat.ts
@@ -1,4 +1,5 @@
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch
+//   - 2 == '2'  true // no strcit type checks, but - 2 === '2' false //type check
 
 import *  as Types from '../types/types';
 import { User } from './User';
@@ -18,11 +19,20 @@ export class Chat {
   }
 
   /* 
-  Not allow:
-  - to all
-  - if blocked seder by receiver
+   User sends  private msg to private chat, if not blocked by another user
+    senderId: UserId //(not SystemId);       
+    receiverId: UserId(if not blocked senderId);    
+    content: string; //not empty
+    type: PyblicMsg;
   */
   sendPrivateMsg(message: Types.Message) {
+
+    if (!message.content || message.content.trim() === "") {
+      throw new Error("cannot send empty message");
+    }
+
+    if (message.type !== 'PrivateMsg')
+      throw new Error("type not private msg");
 
     if (message.receiverId === 'all')
       throw new Error("cannot send private to all");
@@ -36,10 +46,48 @@ export class Chat {
     if (!sender)
       throw new Error("no sender");
 
-    if (message.type == 'PrivateMsg' || message.type == 'PrivateGameInviteMsg') {
-      if (receiver.isBlocked(sender.id))
-        throw new Error("blocked sender by receiver");
+    if (sender.id === Types.SYSTEM_ID)
+      throw new Error("no SystemId sender");
+
+    if (receiver.isBlocked(sender.id))
+      throw new Error("blocked sender by receiver");
+
+    if (receiver.id === Types.SYSTEM_ID)
+      throw new Error("no SystemId receiver");
+
+
+    this.chatMessages.push(message); // TODO(later): send message through WebSocket instead of only saving it
+
+  }
+
+
+  /* 
+ User send public msg to public chat
+    senderId: UserId //(not SystemId);       
+    receiverId: UserId;    
+    content: string; //not empty
+    type: PyblicMsg;
+  
+  */
+  sendPublicMsg(message: Types.Message) {
+
+    if (!message.content || message.content.trim() === "") {
+      throw new Error("cannot send empty message");
     }
+
+    if (message.type !== 'PublicMsg')
+      throw new Error("not public msg");
+
+    if (message.receiverId !== 'all')
+      throw new Error("public msg must receive 'all'");
+
+    const sender = this.userManager.getUserById(message.senderId);
+
+    if (!sender)
+      throw new Error("no sender");
+
+    if (sender.id === Types.SYSTEM_ID)
+      throw new Error("no SystemId sender");
 
     this.chatMessages.push(message); // TODO(later): send message through WebSocket instead of only saving it
 

--- a/backend/src/lib/Class/Chat.ts
+++ b/backend/src/lib/Class/Chat.ts
@@ -1,22 +1,48 @@
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch
+
 import *  as Types from '../types/types';
 import { User } from './User';
+import { UserManager } from './UserManager';
 
 export class Chat {
 
 
 
-
+  userManager: UserManager;
   chatMessages: Types.Message[];
 
-  constructor() {
 
+  constructor(userManager: UserManager) {
+    this.userManager = userManager;
     this.chatMessages = [];
   }
 
+  /* 
+  Not allow:
+  - to all
+  - if blocked seder by receiver
+  */
   sendPrivateMsg(message: Types.Message) {
-    // if(message.type == 'PrivateMsg' || message.type == 'PrivateGameInviteMsg'){
-    // if(user is bocked...)
+
+    if (message.receiverId === 'all')
+      throw new Error("cannot send private to all");
+
+    const receiver = this.userManager.getUserById(message.receiverId);
+    if (!receiver)
+      throw new Error("no receiver");
+
+
+    const sender = this.userManager.getUserById(message.senderId);
+    if (!sender)
+      throw new Error("no sender");
+
+    if (message.type == 'PrivateMsg' || message.type == 'PrivateGameInviteMsg') {
+      if (receiver.isBlocked(sender.id))
+        throw new Error("blocked sender by receiver");
+    }
+
+    this.chatMessages.push(message); // TODO(later): send message through WebSocket instead of only saving it
 
   }
-}
 
+}

--- a/backend/src/lib/Class/Chat.ts
+++ b/backend/src/lib/Class/Chat.ts
@@ -1,9 +1,22 @@
-let name = "Alena";
+import *  as Types from '../types/types';
+import { User } from './User';
+
+export class Chat {
 
 
-function sayHello(name: string) {
-  console.log("Hello, " + name.toUpperCase()); 
+
+
+  chatMessages: Types.Message[];
+
+  constructor() {
+
+    this.chatMessages = [];
+  }
+
+  sendPrivateMsg(message: Types.Message) {
+    // if(message.type == 'PrivateMsg' || message.type == 'PrivateGameInviteMsg'){
+    // if(user is bocked...)
+
+  }
 }
-sayHello(name);
-let car = { car: 'Toyota', brand: 2024 };
-console.log(car);
+

--- a/backend/src/lib/Class/User.ts
+++ b/backend/src/lib/Class/User.ts
@@ -20,7 +20,7 @@ export class User {
 	matchHistory: Types.MatchResult[];
 
 	constructor(name: string, id: string) {
-		
+
 		Validate.ensureNonEmptyString(name, "name");
 		Validate.ensureNonEmptyString(id, "name");
 
@@ -90,6 +90,12 @@ export class User {
 
 	isBlocked(userId: Types.UserId): boolean {
 		return this.blockedIds.has(userId);
+	}
+
+	ensureNotBlockedByOrThrow(userId: Types.UserId): void {
+		if (this.isBlocked(userId)) {
+			throw new Error(`User ${userId} is blocked by ${this.id}`);
+		}
 	}
 
 }

--- a/backend/src/lib/Class/User.ts
+++ b/backend/src/lib/Class/User.ts
@@ -7,6 +7,7 @@
 
 
 import *  as Types from '../types/types';
+import * as Validate from '../utils/validators';
 
 export class User {
 
@@ -19,6 +20,9 @@ export class User {
 	matchHistory: Types.MatchResult[];
 
 	constructor(name: string, id: string) {
+		
+		Validate.ensureNonEmptyString(name, "name");
+		Validate.ensureNonEmptyString(id, "name");
 
 		this.name = name;
 		this.id = id;

--- a/backend/src/lib/Class/UserManager.ts
+++ b/backend/src/lib/Class/UserManager.ts
@@ -3,21 +3,32 @@
 import *  as Types from '../types/types';
 import { User } from './User';
 
-export class UserManager{
+export class UserManager {
 
 	users: Map<Types.UserId, User>;
 
-	constructor(){
+	constructor() {
 		this.users = new Map<Types.UserId, User>;
 	}
 
-	getUserById(userId: Types.UserId):  User | null {
+
+	getUserById(userId: Types.UserId): User | null {
 		return this.users.get(userId) ?? null;
 	}
 
-	saveUser(newUser: User){
+	getUserByIdOrThrow(userId: Types.UserId): User {
+		const user = this.getUserById(userId);
+		if (!user) {
+			throw new Error(`User with id=${userId} is not registered in UserManager`);
+		}
+		return user;
+	}
+
+	saveUser(newUser: User) {
 		this.users.set(newUser.id, newUser);
 	}
 
-	
+
+
+
 }

--- a/backend/src/lib/Class/UserManager.ts
+++ b/backend/src/lib/Class/UserManager.ts
@@ -1,0 +1,15 @@
+import *  as Types from '../types/types';
+import { User } from './User';
+
+export class UserManager{
+
+	users: User[];
+
+	constructor(){
+		this.users = [];
+	}
+
+	get userById(userId: Types.UserId)   {
+		return this.users.has(userId);
+	}
+}

--- a/backend/src/lib/Class/UserManager.ts
+++ b/backend/src/lib/Class/UserManager.ts
@@ -1,15 +1,23 @@
+// Used information from links
+//  https://www.typescriptlang.org/docs/handbook/2/mapped-types.html
 import *  as Types from '../types/types';
 import { User } from './User';
 
 export class UserManager{
 
-	users: User[];
+	users: Map<Types.UserId, User>;
 
 	constructor(){
-		this.users = [];
+		this.users = new Map<Types.UserId, User>;
 	}
 
-	get userById(userId: Types.UserId)   {
-		return this.users.has(userId);
+	getUserById(userId: Types.UserId):  User | null {
+		return this.users.get(userId) ?? null;
 	}
+
+	saveUser(newUser: User){
+		this.users.set(newUser.id, newUser);
+	}
+
+	
 }

--- a/backend/src/lib/types/types.ts
+++ b/backend/src/lib/types/types.ts
@@ -26,11 +26,12 @@ export type MatchResult = {
 };
 
 //_____________CHAT___________
-export type SystemId = "ThisIsSystemID";
+export const SYSTEM_ID = "ThisIsSystemID" as const;
+export type SystemId = typeof SYSTEM_ID;
 
 
 export type MessageType =
-	| 'PublicChatMsg'      
+	| 'PublicMsg'      
 	| 'PrivateMsg'       
 	| 'PrivateGameInviteMsg'   
 	| 'TournamentMsg';   

--- a/backend/src/lib/types/types.ts
+++ b/backend/src/lib/types/types.ts
@@ -29,6 +29,8 @@ export type MatchResult = {
 export const SYSTEM_ID = "ThisIsSystemID" as const;
 export type SystemId = typeof SYSTEM_ID;
 
+export type Message = string;
+
 
 
 export type MessageType =
@@ -72,7 +74,7 @@ interface= object
 export interface MessageBase  {
 
 	senderId: SenderId;          
-	content: string;
+	content: Message;
 };
 
 export interface MessagePrivate extends MessageBase{
@@ -93,5 +95,13 @@ export interface MessagePrivateGameInvite extends MessageBase{
 export interface MessageTournament extends MessageBase{
 	type: 'TournamentMsg';
 	senderId: SystemId;   
-	receiverId: 'all';  
+	receiverId: UserId;  //who will play in tournament
 }
+
+//__________________GAME______________
+
+export const MESSAGE_GAME_INVITE = "Let`s play Ping Pong together! :)" as const;
+export type MessageGameInvite = typeof MESSAGE_GAME_INVITE;
+
+export const MESSAGE_TOURNAMENT_INVITE = "Your tournament starts now! :)" as const;
+export type MessageTournamentInvite = typeof MESSAGE_TOURNAMENT_INVITE;

--- a/backend/src/lib/types/types.ts
+++ b/backend/src/lib/types/types.ts
@@ -30,18 +30,68 @@ export const SYSTEM_ID = "ThisIsSystemID" as const;
 export type SystemId = typeof SYSTEM_ID;
 
 
-export type MessageType =
-	| 'PublicMsg'      
-	| 'PrivateMsg'       
-	| 'PrivateGameInviteMsg'   
-	| 'TournamentMsg';   
 
+export type MessageType =
+| 'PublicMsg'      
+| 'PrivateMsg'       
+| 'PrivateGameInviteMsg'   
+| 'TournamentMsg';   
+
+
+export type SenderId = UserId | SystemId;
 export type Receiver = UserId | 'all';
 
-export type Message = {
+export interface HasPrivateReceiver{
+	receiverId: UserId;	
+}
+export interface HasPublicReceiver{
+	receiverId: 'all';			
+}
 
-	senderId: UserId | SystemId;       
-	receiverId: Receiver;    
+export interface HasPrivateSender{
+	senderId: UserId;	
+}
+export interface HasServerSender{
+	senderrId: SystemId;			
+}
+
+
+// export type Message = {
+
+// 	senderId: UserId | SystemId;       
+// 	receiverId: Receiver;    
+// 	content: string;
+// 	type: MessageType;
+// };
+
+/* 
+used info for interface:
+https://www.typescriptlang.org/docs/handbook/2/everyday-types.html
+interface= object
+*/
+export interface MessageBase  {
+
+	senderId: SenderId;          
 	content: string;
-	type: MessageType;
 };
+
+export interface MessagePrivate extends MessageBase{
+	type: 'PrivateMsg';
+	senderId: UserId; 	 //override MessageBase: must be a real user
+	receiverId: UserId;  
+}
+export interface MessagePublic extends MessageBase{
+	type: 'PublicMsg';
+	senderId: UserId;   
+	receiverId: 'all';  
+}
+export interface MessagePrivateGameInvite extends MessageBase{
+	type: 'PrivateGameInviteMsg';
+	senderId: UserId;   
+	receiverId: UserId;  
+}
+export interface MessageTournament extends MessageBase{
+	type: 'TournamentMsg';
+	senderId: SystemId;   
+	receiverId: 'all';  
+}

--- a/backend/src/lib/types/types.ts
+++ b/backend/src/lib/types/types.ts
@@ -11,6 +11,7 @@ or what you  special need:
 import { UserId, UserStatus, MatchResult } from './types/types';
 */
 
+//___________USER
 export type UserStatus = 'online' | 'offline';
 export type GameResult = 'won' | 'lost';
 export type UserId = string;
@@ -22,4 +23,24 @@ export type MatchResult = {
 	opponentId: UserId;
 	date: Date;
 	result: GameResult;
-  };
+};
+
+//_____________CHAT___________
+export type SystemId = "ThisIsSystemID";
+
+
+export type MessageType =
+	| 'PublicChatMsg'      
+	| 'PrivateMsg'       
+	| 'PrivateGameInviteMsg'   
+	| 'TournamentMsg';   
+
+export type Receiver = UserId | 'all';
+
+export type Message = {
+
+	senderId: UserId | SystemId;       
+	receiver: Receiver;    
+	content: string;
+	type: MessageType;
+};

--- a/backend/src/lib/types/types.ts
+++ b/backend/src/lib/types/types.ts
@@ -40,7 +40,7 @@ export type Receiver = UserId | 'all';
 export type Message = {
 
 	senderId: UserId | SystemId;       
-	receiver: Receiver;    
+	receiverId: Receiver;    
 	content: string;
 	type: MessageType;
 };

--- a/backend/src/lib/utils/validators.ts
+++ b/backend/src/lib/utils/validators.ts
@@ -1,0 +1,21 @@
+
+  /* 
+ not empty string
+ fieldname: "username", "senderId", "message content"...
+  */
+  export function ensureNonEmptyString(value: string, fieldName: string): void {
+	if (!value || value.trim() === "") {
+	  throw new Error(`${fieldName} cannot be empty`);
+	}
+  }
+  
+  export function ensureNotSystemId(userId: string, systemId: string): void {
+	if (userId === systemId) {
+	  throw new Error("SystemId cannot be used here");
+	}
+  }
+
+//   export function ensureNotSystemId(userId: string, systemId: string)
+//   {
+
+//   }

--- a/backend/src/lib/utils/validators.ts
+++ b/backend/src/lib/utils/validators.ts
@@ -1,21 +1,32 @@
 
-  /* 
- not empty string
- fieldname: "username", "senderId", "message content"...
-  */
-  export function ensureNonEmptyString(value: string, fieldName: string): void {
-	if (!value || value.trim() === "") {
-	  throw new Error(`${fieldName} cannot be empty`);
+export function isEmptyString(value: string): boolean {
+	return !value || value.trim() === "";
+}
+
+/* 
+not empty string
+fieldname: "username", "senderId", "message content"...
+*/
+export function ensureNonEmptyString(value: string, fieldName: string): void {
+	if (isEmptyString(value)) {
+		throw new Error(`${fieldName} cannot be empty`);
 	}
-  }
-  
-  export function ensureNotSystemId(userId: string, systemId: string): void {
+}
+
+export function ensureNotSystemId(userId: string, systemId: string): void {
 	if (userId === systemId) {
-	  throw new Error("SystemId cannot be used here");
+		throw new Error("SystemId cannot be used here");
+	}
+}
+
+export function ensureIsSystemId(userId: string, systemId: string): void {
+	if (userId !== systemId) {
+	  throw new Error("Only SystemId can be used here");
 	}
   }
 
-//   export function ensureNotSystemId(userId: string, systemId: string)
-//   {
-
-//   }
+export function ensureReceiverIsAll(receiverId: string): void {
+	if (receiverId !== 'all') {
+		throw new Error("receiverId must be 'all'");
+	}
+}

--- a/backend/tests/chat_test.ts
+++ b/backend/tests/chat_test.ts
@@ -1,10 +1,80 @@
-
 import assert from "assert";
-import * as chat from "../src/lib/Class/Chat";
+import { Chat } from "../src/lib/Class/Chat";
+import { User } from "../src/lib/Class/User";
+import { UserManager } from "../src/lib/Class/UserManager";
+import * as Types from "../src/lib/types/types";
 
-function runTests() {
-  console.log(chat)
-  console.log("Chat test passed!");
+function runChatTests() {
+  const userManager = new UserManager();
+  const alice = new User("Alice", "u1");
+  const bob = new User("Bob", "u2");
+  userManager.saveUser(alice);
+  userManager.saveUser(bob);
+
+  const chat = new Chat(userManager);
+
+  // 1. Public message
+  chat.sendPublicMessage({
+    type: "PublicMsg",
+    senderId: alice.id,
+    receiverId: "all",
+    content: "Hello world!"
+  });
+  assert.strictEqual(chat.chatMessages.length, 1);
+
+  // 2. Private message
+  chat.sendPrivateMessage({
+    type: "PrivateMsg",
+    senderId: alice.id,
+    receiverId: bob.id,
+    content: "Hi Bob"
+  });
+  assert.strictEqual(chat.chatMessages.length, 2);
+
+  // 3. Blocked user cannot send private msg
+  bob.blockId(alice.id);
+  assert.throws(() => {
+    chat.sendPrivateMessage({
+      type: "PrivateMsg",
+      senderId: alice.id,
+      receiverId: bob.id,
+      content: "Still there?"
+    });
+  });
+
+  // ✅ unblock before testing game invite
+  bob.unblockId(alice.id);
+
+  // 4. Private game invite auto-fills content if empty
+  chat.sendPrivateGameInviteMessage({
+    type: "PrivateGameInviteMsg",
+    senderId: alice.id,
+    receiverId: bob.id,
+    content: "" // should be replaced with default invite text
+  });
+  const lastInvite = chat.chatMessages[chat.chatMessages.length - 1] as Types.MessagePrivateGameInvite;
+  assert.strictEqual(lastInvite.content, Types.MESSAGE_GAME_INVITE);
+
+  // 5. Tournament system message
+  chat.sendTournamentMessage({
+    type: "TournamentMsg",
+    senderId: Types.SYSTEM_ID,
+    receiverId: alice.id,
+    content: "" // should be replaced with default tournament text
+  });
+  const lastTournament = chat.chatMessages[chat.chatMessages.length - 1] as Types.MessageTournament;
+  assert.strictEqual(lastTournament.content, Types.MESSAGE_TOURNAMENT_INVITE);
+
+  // 6. Empty public message → throws
+  assert.throws(() => {
+    chat.sendPublicMessage({
+      type: "PublicMsg",
+      senderId: alice.id,
+      receiverId: "all",
+      content: ""
+    });
+  });
 }
 
-runTests();
+runChatTests();
+console.log(":) Chat tests passed :) ");


### PR DESCRIPTION

## add CLasses:  Chat + UserManager. 
## add validator.ts (common for all classes in /backend/src/lib/utils/validators.ts)
## add full chat_tests.ts (/backend/tests/chat_test.ts)


Adds first version of chat system with user manager.
Supports private and public messages, blocking, invites, and tournament messages.
Includes unit tests for the main features.

---

### feat(userManager,Chat): started class chat, need first class userManager

Made `UserManager` to store users in a map.
Added basic get and save methods.
Started `Chat` that uses `UserManager`.

### feat(Chat): use class userManager in Chat, add new function sendPrivateMsg

Hooked `UserManager` into `Chat`.
Added `sendPrivateMsg` for direct messages.
Checks that both users exist before sending.

### feat(Chat): update sendPrivateMsg(), add new sendPublicMsg()

Improved private message checks.
Added `sendPublicMsg` for all users.
Separated message types for clarity.

### test: add Chat module unit tests

Added tests for private messages.
Added tests for blocking and game invites.
Added tests for tournament notifications.

---

Tests for backend can be run in terminal with:

```bash
make backend-tests
```



