### PR TITLE
Update README.md with  new current team roles and  module instead 2Fa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,226 +1,310 @@
-# 🏓 ft_transcendence
 
-A real-time Pong web app with **secure auth (JWT + 2FA)**, **remote multiplayer** over **WSS**, **live chat**, **AI opponent**, and a **TypeScript SPA** styled with **Tailwind**.  
-Goal: **one Docker command** to run; must work in **Firefox** (also tested in Chrome).
+___________
+#     🏓    /ft_transcendence-ping-pong-website    🏓 
+_______________
+🚧 **Status: In Progress** 🚧  
 
----
-
-## 📚 Menu
-
-- [1) Project Description](#1-project-description)  
-- [2) Modules (Main + 7 majors)](#2-modules-main--7-majors)  
-- [3) Team Roles (overview + detailed tasks)](#3-team-roles-overview--detailed-tasks)  
-- [4) How to Run](#4-how-to-run)  
-- [5) Folder Structure](#5-folder-structure)  
-- [6) Compliance Checklist](#6-compliance-checklist)  
-- [7) Clarifications (Subject & Eval)](#7-clarifications-subject--eval)
+Final capstone project at [42 Berlin](https://42berlin.de/) — a project-based, peer-to-peer software engineering program.  
+At 42, students learn by **building real systems**, **reviewing each other’s code**, and **defending their work live**.  
+This repository reflects that approach: teamwork, code reviews, and strict compliance with technical specifications.
 
 ---
 
-## 1) Project Description
+## 👥 Team
 
-### What it is
-Multiplayer **Pong** in the browser with:  
-- **Live Chat** (DM, block, invite)  
-- **Tournament** (alias-only or accounts)  
-- **AI Opponent** (same rules/speed as humans)  
-- **Profiles & stats**
+| | Member | Role | GitHub |
+|-|---------|------|--------|
+|🟣|**Alena**| Backend & Real-Time Lead (Fastify, User Mgmt, Sockets, Chat) | [@42Alena](https://github.com/42Alena) |
+|🟢| **Sveva**| Game & Frontend Lead (Canvas, AI, Tailwind, Customization) | [@svevotti](https://github.com/svevotti) |
+|🔵|  **Luis**| **Database & Data Protection Lead** (SQLite schema & migrations, WAL/perf, data lifecycle, GDPR deletion/anonymization, observability & DB health) | [@Numbersdontlie](https://github.com/Numbersdontlie) |
 
-Delivered as a **single-page app** started with **one Docker command**.
-
-### How it works
-- **Frontend:** **TypeScript SPA (no frontend framework)** + **Tailwind**.  
-  Uses the **History API** (Back/Forward works without reloads).  
-- **Backend:** **Fastify (Node.js)** + **SQLite**. REST APIs + **Socket.IO** for realtime (**WSS** in production).  
-- **Realtime model:** One **Socket.IO room per match**; disconnect → pause; reconnect → resume with state.  
-- **Security:** **HTTPS/WSS**, **JWT in HttpOnly, Secure, SameSite=Strict cookies** (not localStorage), server-side validation, **Argon2id** password hashing, secrets in `.env`.
+[↑ back to top](#-ft_transcendence-ping-pong-website)
 
 ---
 
-## 2) Modules (Main + 7 majors)
+## 🛠 Tech Stack
 
-| Module | Lead | Where (paths) | Tools | Acceptance |
+[![TypeScript](https://img.shields.io/badge/TypeScript-4.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Fastify](https://img.shields.io/badge/Fastify-Backend-000000?logo=fastify&logoColor=white)](https://fastify.dev/)
+[![Socket.IO](https://img.shields.io/badge/Socket.IO-Realtime-010101?logo=socketdotio&logoColor=white)](https://socket.io/)
+[![SQLite](https://img.shields.io/badge/SQLite-DB-003B57?logo=sqlite&logoColor=white)](https://www.sqlite.org/)
+[![Tailwind CSS](https://img.shields.io/badge/Tailwind-CSS-38B2AC?logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
+[![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
+[![42 Berlin](https://img.shields.io/badge/42-Berlin-000000?logo=42&logoColor=white)](https://42berlin.de/)
+
+[↑ back to top](#-ft_transcendence-ping-pong-website)
+
+---
+
+## 🧭 Navigation
+- [Project Overview](#-project-overview)
+- [About 42 Berlin](#-about-42-berlin)
+- [Modules (Main + 7 majors)](#-modules-main--7-majors)
+- [Team & Responsibilities](#-team--responsibilities)
+- [Tech & Languages](#-tech--languages)
+- [Folder Structure](#-folder-structure-important-parts-only)
+- [How to Run](#-how-to-run)
+- [Security & Privacy](#-security--privacy)
+- [Evaluation Checklist](#-evaluation-checklist-internal)
+- [Contributors](#-contributors)
+- [License](#-license)
+
+[↑ back to top](#-ft_transcendence-ping-pong-website)
+
+---
+
+## 🌟 Project Overview
+
+We are developing a **production-ready, secure, single-page web application** built around the classic **Pong** game.  
+
+Key features include:
+- 🎮 **Remote Multiplayer** – WebSockets with safe reconnect, pause/resume on disconnect.  
+- 💬 **Live Chat** – Direct messages, block list, match invites, notifications.  
+- 🤖 **AI Opponent** – Subject-compliant: keyboard simulation only, refresh every 1s, same paddle speed, can win, uses power-ups.  
+- 👥 **Profiles & Stats** – Accounts, avatars, friends/online, match history.  
+- 🔐 **Privacy by Design** – GDPR endpoints for account deletion & anonymization.  
+- 🚀 **Deployment** – HTTPS/WSS via proxy, reproducible with **one Docker command**.  
+- 🎨 **Frontend** – TypeScript + Tailwind SPA (no framework, History API navigation).  
+- 🧰 **Data reliability (Luis)** — consistent schema, constraints, WAL journaling, DB health checks, safe deletes/anonymization.
+
+**Goal:** Run everything with one Docker command.  
+**Requirement:** Must work in Firefox (also tested in Chrome).  
+
+[↑ back to top](#-ft_transcendence-ping-pong-website)
+
+---
+
+## 🌍 About 42 Berlin
+
+[42 Berlin](https://42berlin.de/) is part of the international 42 network:  
+- **Project-based learning** — no teachers, no lectures.  
+- **Peer-to-peer collaboration** — students review and defend each other’s work.  
+- **Industry focus** — projects simulate real-world software engineering challenges.  
+
+ft_transcendence is the **final web project** in the curriculum: it proves skills in **web security, real-time networking, databases, and deployment**.
+
+[↑ back to top](#-ft_transcendence-ping-pong-website)
+
+---
+
+## 📌 Modules (Main + 7 majors)
+
+> **Current plan (subject-compliant) — may change as the project evolves.**  
+
+| Module (subject name) | Lead | Where (paths) | Tools | Acceptance |
 |---|---|---|---|---|
-| **MAIN (SPA, Docker, HTTPS/WSS)** | All | `frontend/`, root `docker-compose.yml` | TS SPA + proxy | SPA Back/Forward works; one command boots all; alias-only tournament works. |
-| **Fastify backend** | Luis | `backend/src/**` | Fastify + SQLite | REST routes with schemas; `/healthz`; DB bootstrap. |
-| **User Management** | Sveva (+Luis) | `backend/src/routes/**`, `frontend/src/**` | TS + Fastify | Register/Login, profile, friends/online, stats/history. |
-| **2FA + JWT** | Luis | `backend/src/auth/**` | jsonwebtoken, otplib | TOTP enroll/verify; JWT in HttpOnly cookie; protected routes. |
-| **Remote Players** | Alena | `backend/src/main.ts` (sockets) | Socket.IO | Rooms; paddle/ball/score sync; reconnect safety. |
-| **Live Chat** | Alena | `frontend/src/chat/**`, `backend/src/**` | Socket.IO + TS | DM/block/invite; notifications. |
-| **Tailwind + Customization (2 minors)** | Alena | `frontend/src/settings/**` | Tailwind + TS | Settings UI (speed, paddle size, power-ups); synced to gameplay & AI. |
-| **AI Opponent** | Sveva | `frontend/src/game/**` | Canvas + TS | AI: keyboard sim, 1s refresh, same paddle speed; can win; uses power-ups. |
+| **MAIN (SPA, Docker, HTTPS/WSS)** | **Alena  Luis  Sveva** | `frontend/`, root `docker-compose.yml` | TS SPA + proxy | SPA Back/Forward works; one command boots all; alias-only tournament works. |
+| **[Web — Fastify backend]** | **Alena** | `backend/src/**` | Fastify | REST routes with JSON schemas; `/healthz` returns 200. |
+| **[User Management — Standard User Management]** | **Alena** | `backend/src/lib/Class/**` | TypeScript + Fastify | Register/login; profiles; avatars; friends/online; stats/history; passwords hashed. |
+| **[Gameplay & UX — Remote Players]** | **Alena** | `backend/src/main.ts` (sockets) | Socket.IO | Rooms; paddle/ball/score sync with timestamps; reconnect safety. |
+| **[Gameplay & UX — Live Chat]** | **Alena** | `frontend/src/chat/**`, `backend/src/**` | Socket.IO + TS | DM/block/invite; tournament notifications; profile view from chat. |
+| **[Web (minor) — Tailwind] + [Gameplay & UX (minor) — Game Customization]** | **Sveva** | `frontend/src/ui/**`, `frontend/src/settings/**` | Tailwind + TS | Responsive UI; settings (speed, paddle size, power-ups) applied to game & AI. |
+| **[AI-Algo — AI Opponent]** | **Sveva** | `frontend/src/game/**` | Canvas + TS | Keyboard sim only; refresh every 1s; same paddle speed as humans; can win; uses power-ups. |
+| **[Web (minor) — SQLite: Schema & Init]** *(counts)* | **Luis** | `backend/src/db/**` | SQLite + TS | **Idempotent migrations; foreign keys enforced; WAL mode; unique constraints; indices on hot paths; DB health endpoint green.** |
+| **[Cybersecurity (minor) — GDPR/Account Deletion]** *(counts)* | **Luis** | `backend/src/routes/gdpr.ts` | Fastify | **DELETE → hard-delete user + anonymize match history; POST /anonymize → mask PII (username/avatar/email); audit-safe logs; race-safe with transactions.** |
 
-> **AI – 3 hard constraints (explicit):**  
-> 1) **Keyboard Simulation Only** (never set paddle position directly).  
-> 2) **View Refresh = 1 second** (predict bounces between refreshes).  
-> 3) **Same paddle speed** as humans (no cheating); if power-ups exist, **AI uses them**.
+**Total:** 5 direct majors + (Tailwind+Customization = 1 major) + (SQLite+GDPR = 1 major) → **7 majors** ✅
+
+[↑ back to top](#-ft_transcendence-ping-pong-website)
 
 ---
 
-## 3) Team Roles (overview + detailed tasks)
+## 👥 Team & Responsibilities
 
-### 3.1 Common team tasks
-- Keep **contracts** (events, DTOs, constants) consistent across backend & frontend.  
-- Branch → PR → review; clean commits.  
-- Maintain `.env.example`; never commit secrets.  
-- Test on **Firefox** (mandatory) and Chrome (optional).  
-- Ensure **SPA Back/Forward** works (History API + proxy fallback).  
-- Keep **Docker** reproducible (one command from repo root).
+### 🟣  Alena — Backend & Real-Time Lead  
+**Modules:** Fastify backend · User Management · Remote Players · Live Chat  
 
-### 3.2 Roles overview
-
-| Person | Role | High-level steps | Tools |
+| Area | Tasks | Why (subject link) | Acceptance |
 |---|---|---|---|
-| **Alena** | Real-Time Systems Lead | Socket layer (JWT handshake, rooms, events, reconnect), remote sync (paddle/ball/score), **Live Chat** (DM/block/invite), **Customization UI** (Tailwind), shared contracts. | TypeScript, Socket.IO, Tailwind, Vite (dev), Docker Compose |
-| **Luis** | Backend & Auth Lead | Fastify bootstrap, SQLite schema/migrations, REST (auth/2FA, me, matches, friends, history), **JWT in HttpOnly cookie**, **TOTP 2FA**, WS auth, `.env` loader/docs, **Argon2id** hashing. | TypeScript, Fastify, SQLite, argon2/bcrypt, jsonwebtoken, otplib |
-| **Sveva** | Game Logic & AI Lead | Canvas loop (local 2P), physics/collisions, **Tournament** (alias, bracket, next-match), **AI** (keyboard sim, 1s refresh, predictive, same speed, can win, uses power-ups), apply customization, save results & stats. | TypeScript, Canvas API, game math, Socket.IO (client), REST/Fetch |
-
-### 3.3 Detailed task tables
-
-#### 👤 Alena — Real-Time Systems Lead
-| Task | Path | Tools | Priority | Acceptance |
-|---|---|---|---:|---|
-| JWT handshake → `socket.data.userId` | `backend/src/main.ts` | Socket.IO | 5 | Invalid JWT refused; valid sockets have `userId`. |
-| Match rooms (join/leave; lifecycle) | `backend/src/main.ts` | Socket.IO | 5 | Membership tracked; cleanup on leave. |
-| Paddle/ball/score sync (throttled; timestamps) | `backend/src/main.ts` | Socket.IO | 5 | Opponent sees paddle quickly; ball snapshots timestamped. |
-| Reconnect policy (pause → rejoin → catch-up) | `backend/src/main.ts` | Socket.IO | 5 | Disconnect pauses; reconnect resends state. |
-| Live Chat (DM/block/invite) | `frontend/src/chat/**` + `backend/src/**` | TS + Tailwind + Socket.IO | 6 | Block works; invite creates match; notifications appear. |
-| Tailwind base + HUD | `frontend/src/ui/**` (planned) | Tailwind | 7 | Consistent typography; responsive HUD. |
-| Settings UI | `frontend/src/settings/**` | TS + Tailwind | 7 | Settings affect gameplay & AI. |
-| Shared contracts | `frontend/src/shared/**` (planned) | TS | 7 | Coordinated changes across team. |
-
-#### 🔒 Luis — Backend & Auth Lead
-| Task | Path | Tools | Priority | Acceptance |
-|---|---|---|---:|---|
-| Fastify bootstrap (CORS, errors, logging) | `backend/src/main.ts` | Fastify | 2 | `/healthz` 200; CORS correct. |
-| SQLite schema + migrations | `backend/src/db/**` | better-sqlite3 | 2 | Tables created idempotently. |
-| REST routes: auth/2FA, `/me`, matches, friends | `backend/src/routes/**` | Fastify | 2 | JSON schema validation; correct 2xx/4xx. |
-| Argon2id password hashing | `backend/src/auth/**` | argon2/bcrypt | 4 | Strong params; verified on login. |
-| JWT issue/verify → HttpOnly cookie | `backend/src/auth/**` | jsonwebtoken | 4 | `HttpOnly; Secure; SameSite=Strict`; expiry ~1h. |
-| TOTP 2FA enroll/verify | `backend/src/auth/**` | otplib | 4 | QR enroll; code verified. |
-| WS auth (JWT in handshake) | `backend/src/main.ts` | Fastify + Socket.IO | 4 | Missing/invalid token refused. |
-| `.env` loader + docs | `backend/` | dotenv | 2 | Fails fast if env missing. |
-
-#### 🎮 Sveva — Game Logic & AI Lead
-| Task | Path | Tools | Priority | Acceptance |
-|---|---|---|---:|---|
-| Canvas loop + local 2-player | `frontend/src/game/canvas/**` | TS + Canvas | 1 | Two paddles; 60fps; scoring correct. |
-| Physics & collisions | `frontend/src/game/logic/**` | TS | 1 | Deterministic; no tunneling. |
-| Tournament (alias-only + bracket) | `frontend/src/tournament/**` | TS (+ sockets) | 3 | Alias flow without login; bracket notifies next match. |
-| AI: keyboard sim, 1s refresh, same speed | `frontend/src/game/ai/**` | TS | 8 | Meets constraints; human vs AI playable. |
-| Apply customization to physics & AI | `frontend/src/game/**` | TS | 7 | Settings affect gameplay & AI. |
-| Save start/end; update stats/history | `backend/src/routes/**` | REST calls | 3 | History shows opponent, score, flags. |
+| **Fastify backend** | REST skeleton with `/healthz`, `/users`, `/matches`; JSON schema validation; error handling; Docker integration | Required by *Web — Fastify backend* | `curl /healthz` → 200; invalid payload rejected |
+| **User Management** | Domain classes (`User`, `UserManager`, `Chat`); register/login; profiles; avatars; friends/online; stats/history; passwords hashed | Matches *Standard User Management* module | Register/login works; profile shows avatar/stats; password in DB is hashed |
+| **Remote Players** | Socket.IO rooms; join/leave lifecycle; paddle/ball/score sync with timestamps; reconnect = pause/resume | Matches *Remote Players* module | Two browsers play; unplug → game pauses; replug → resumes |
+| **Live Chat** | DM/block/invite; tournament notifications; profile peek from chat; shared DTOs/events with frontend | Matches *Live Chat* module | Blocked DM refused; invite → match created; notification visible |
 
 ---
 
-## 4) How to Run
+### 🟢 Sveva — Game & Frontend Lead  
+**Modules:** Tailwind + Customization · AI Opponent  
 
-### 🧪 Development (Vite on :5173, Fastify on :3000)
+| Area | Tasks | Why (subject link) | Acceptance |
+|---|---|---|---|
+| **Tailwind UI** | Responsive SPA layout; resize handling; colors & typography; HUD styled consistently | Required by *Web (minor) — Tailwind* | Resize window → layout adapts; no overflow |
+| **Customization menu** | Paddle size, ball speed, power-ups; settings applied to game + AI | Required by *Gameplay & UX (minor) — Customization* | Change paddle size → affects both player & AI |
+| **Rendering & physics** | Frame-timed render loop (`requestAnimationFrame`); deterministic physics; paddle/ball collisions; scoring; stable under resize/tab-switch | Needed for core gameplay | Game runs smoothly; no tunneling; score updates correctly |
+| **AI Opponent** | Keyboard simulation only; refresh every 1s; same paddle speed as human; uses power-ups; can win | Explicit rules in *AI Opponent* module | AI key presses logged; wins some games |
+| **Tournament (alias)** | Alias entry; bracket flow; “next match” notification | Subject requires alias-only tournament | Start tournament without login → next match displayed |
+
+---
+
+### 🔵  Luis — Database & Data Protection Lead  
+**Modules:** SQLite · GDPR/Account Deletion  
+
+| Area | Tasks | Why (subject link) | Acceptance |
+|---|---|---|---|
+| **SQLite schema & integrity** | Design `users`, `matches` (FKs, `ON DELETE SET NULL`/`CASCADE` where sensible), unique constraints (username/email), indices (e.g., `matches(winner_id, created_at)`), **PRAGMA foreign_keys=ON** | Required by *SQLite: Schema & Init* | Schema created idempotently; FKs enforced; inserts violating constraints fail with clear errors |
+| **Migrations & startup** | Idempotent migration scripts at boot; safe re-run; seed for local dev; **WAL journaling** for concurrent reads; **busy timeout** | Operability & stability | Multiple restarts don’t duplicate; WAL active; DB health green |
+| **DB health & observability** | `/db/health` route (returns PRAGMA checks + file size + WAL status); log slow queries (>50ms) | Evaluator clarity | `curl /db/health` → 200 JSON with status: "ok" |
+| **Backups & maintenance** | Document portable backup (`sqlite3 app.db ".backup app.backup.db"`); periodic `VACUUM` and `ANALYZE` guidance; volume path configurable (`SQLITE_PATH`) | Data safety in demo/eval | Backup file created; DB size stable after vacuum |
+| **GDPR endpoints** | `DELETE /users/:id` → hard-delete account, **anonymize** matches (keep gameplay stats but remove PII); `POST /users/:id/anonymize` → mask PII (username/avatar/email) while keeping relationships | Required by *GDPR/Account Deletion* | Hitting endpoints updates DB correctly; subsequent profile fetch shows masked/removed data |
+| **Transaction safety** | Wrap GDPR ops in a single transaction; handle races (e.g., simultaneous match write) via retry/backoff | Consistency under load | No half-deleted state; logs show committed tx |
+
+[↑ back to top](#-ft_transcendence-ping-pong-website)
+
+---
+
+## 🧪 Tech & Languages
+
+- **Languages:** TypeScript, HTML, CSS  
+- **Runtime:** Node.js  
+- **Backend:** Fastify, Socket.IO (WSS), SQLite  
+- **Frontend:** TypeScript + Tailwind (no framework; History API)  
+- **Security:** HTTPS/WSS, Argon2id password hashing, GDPR endpoints  
+- **Ops (Luis):** **WAL mode**, **foreign_keys ON**, **idempotent migrations**, **DB health route**, **documented backup** procedure, **.env** with `SQLITE_PATH`
+
+[↑ back to top](#-ft_transcendence-ping-pong-website)
+
+---
+
+## 🗂️ Folder Structure (important parts only)
+
+```
+
+.
+├─ backend/
+│  ├─ src/
+│  │  ├─ db/              # ← (Luis) migrations, sqlite helpers, pragmas, health checks
+│  │  ├─ lib/Class/       # User, Chat, UserManager
+│  │  ├─ types/           # Shared backend types
+│  │  ├─ utils/           # Validation helpers
+│  │  ├─ routes/          # REST API (chat, GDPR, users, db/health)
+│  │  └─ main.ts          # Fastify entrypoint + sockets
+│  ├─ tests/              # Unit / integration tests
+│  ├─ Dockerfile
+│  └─ package.json
+│
+├─ frontend/
+│  ├─ public/             # Host page + assets
+│  │  ├─ styles/index.html# SPA host page
+│  │  └─ styles/style.css # Stylesheet
+│  └─ src/                # SPA source (chat, game, ui, settings planned)
+│
+├─ docker-compose.yml
+└─ README.md
+
+````
+
+[↑ back to top](#-ft_transcendence-ping-pong-website)
+
+---
+
+## 🚀 How to Run
+
+### Production / Evaluation
+```bash
+git clone <this-repo>
+cd ft_transcendence
+cp .env.example .env
+docker-compose up --build
+
+# Open:
+https://localhost
+````
+
+### Development
 
 ```bash
-# Terminal 1 — backend
+# Backend
 cd backend
 npm ci
 npm run dev
 
-# Terminal 2 — frontend
+# Frontend
 cd frontend
-npm ci
-npm run dev
-````
+# serve /public or /dist as static content
 
-Open: **[https://localhost:5173](https://localhost:5173)**
-
-### 📦 Production / Evaluation (Docker, proxy on :443)
-
-```bash
-git clone <repo>
-cd ft_transcendence
-cp .env.example .env
-docker-compose up --build
+# Open (dev):
+https://localhost:5173
 ```
-
-Open: **[https://localhost](https://localhost)**
 
 **Services & Ports**
 
-| Service  | Path        | Dev Port | Prod (via proxy) | Notes                             |
-| -------- | ----------- | -------: | ---------------: | --------------------------------- |
-| Backend  | `backend/`  |     3000 |       443 → 3000 | Fastify + SQLite; Socket.IO (WSS) |
-| Frontend | `frontend/` |     5173 |     443 → static | TS SPA + Tailwind (Vite in dev)   |
-| Proxy    | compose svc |        — |              443 | TLS termination; WS upgrade       |
+* Proxy → `443` (TLS termination, WS upgrade)
+* Backend → `3000` (proxied behind 443, WSS enabled)
+* Frontend → static via proxy (`/`)
 
 **Required env vars**
 
-| Var            | Where    | Example                                          | Purpose            |
-| -------------- | -------- | ------------------------------------------------ | ------------------ |
-| PORT           | backend  | 3000                                             | API port           |
-| APP\_URL       | backend  | [https://localhost](https://localhost)           | CORS/cookie origin |
-| JWT\_SECRET    | backend  | change\_me\_please                               | JWT sign/verify    |
-| SQLITE\_PATH   | backend  | ./data/app.db                                    | DB file path       |
-| TWOFA\_ISSUER  | backend  | ft\_transcendence                                | TOTP issuer        |
-| VITE\_API\_URL | frontend | [https://localhost:3000](https://localhost:3000) | API base URL       |
+| Var           | Where   | Example             | Purpose            |
+| ------------- | ------- | ------------------- | ------------------ |
+| `PORT`        | backend | `3000`              | API port           |
+| `APP_URL`     | backend | `https://localhost` | CORS/cookie origin |
+| `SQLITE_PATH` | backend | `./data/app.db`     | DB file path       |
 
----
+**(Luis) Useful DB ops during defense**
 
-## 5) Folder Structure
+```bash
+# Health:
+curl -s https://localhost/db/health | jq
 
-```
-.
-├─ backend/                 # Fastify backend (TypeScript)
-│  ├─ src/
-│  │  ├─ routes/            # REST API route handlers
-│  │  ├─ db/                # DB schema/migrations (planned)
-│  │  ├─ auth/              # Auth logic: JWT + 2FA (planned)
-│  │  └─ main.ts            # Fastify entrypoint + sockets
-│  ├─ Dockerfile            # Backend Dockerfile
-│  ├─ package.json          # Backend deps + scripts
-│  └─ tsconfig.json         # TypeScript config
-│
-├─ frontend/                # SPA (TypeScript + Tailwind + Vite)
-│  ├─ src/
-│  │  ├─ chat/              # Chat UI (planned)
-│  │  ├─ settings/          # Game customization UI (planned)
-│  │  ├─ game/              # Canvas, AI, logic (planned)
-│  │  ├─ tournament/        # Tournament screens (planned)
-│  │  ├─ ui/                # HUD, shared components (planned)
-│  │  └─ main.ts            # SPA entry
-│  ├─ index.html            # SPA host page
-│  ├─ vite.config.ts        # Vite config
-│  └─ tailwind.config.js    # Tailwind config
-│
-├─ docs/                    # Project docs
-├─ docker-compose.yml       # One-command runner
-├─ .env.example             # Example environment variables
-└─ README.md                # This document
+# Safe backup (file-copy friendly):
+sqlite3 ./data/app.db ".backup ./data/app.backup.db"
+
+# Inspect pragmas quickly:
+sqlite3 ./data/app.db "PRAGMA journal_mode; PRAGMA foreign_keys;"
 ```
 
----
-
-## 6) Compliance Checklist
-
-* [x] TypeScript SPA (no frontend framework), Back/Forward works
-* [x] Works in **Firefox** (mandatory) and Chrome (optional)
-* [x] One Docker command from repo root
-* [x] HTTPS + WSS everywhere
-* [x] JWT in **HttpOnly, Secure, SameSite=Strict cookies** (not localStorage)
-* [x] Passwords hashed (Argon2id or strong bcrypt)
-* [x] Tournament supports alias-only + accounts
-* [x] Remote players with reconnect safety
-* [x] Live Chat: DM, block, invite, notifications
-* [x] AI: keyboard simulation, refresh = 1s, same paddle speed, can win
+[↑ back to top](#-ft_transcendence-ping-pong-website)
 
 ---
 
-## 7) Clarifications (Subject & Eval)
+## 🔐 Security & Privacy
 
-* Tournament: must work with only an alias (no login required).
-* JWT: must not be stored in localStorage. Only in HttpOnly, Secure, SameSite=Strict cookies.
-* 2FA: TOTP with authenticator app (QR enroll + code verify).
-* AI: must simulate keyboard input, refresh its view every second, use same paddle speed, and use power-ups if present.
-* Proxy: must terminate TLS (443) and forward WebSocket upgrade on `/socket.io`.
-* Hard fails: secrets in git, missing `docker-compose.yml` at root, no HTTPS/WSS, SPA reloads instead of History API.
+* **HTTPS/WSS** enforced in production.
+* **Passwords**: Argon2id or bcrypt.
+* **GDPR (Luis):**
+
+  * `DELETE /users/:id` → remove account; **anonymize** references in `matches` so statistics remain but PII does not.
+  * `POST /users/:id/anonymize` → mask personal fields while keeping account for gameplay history.
+  * All GDPR mutations run inside a **transaction**; logs include request IDs for traceability.
+* **Data minimization:** only store what gameplay needs (user id, alias, match stats).
+
+[↑ back to top](#-ft_transcendence-ping-pong-website)
 
 ---
 
-Crafted with teamwork by Alena, Luis & Sveva.
+## ✅ Evaluation Checklist (internal)
+
+* TypeScript SPA (no frontend framework), Back/Forward works
+* Works in **Firefox** (mandatory) and Chrome (optional)
+* One Docker command from repo root
+* HTTPS + WSS everywhere
+* Tournament supports **alias-only** + accounts
+* Remote players with reconnect safety
+* Live Chat: **DM, block, invite, notifications**
+* AI: **keyboard simulation**, **refresh = 1s**, **same paddle speed**, **can win**
+* GDPR: **delete/anonymize** endpoints functional
+* **DB (Luis):** WAL on; foreign keys enforced; migrations idempotent; `/db/health` returns **ok**; backup command demonstrated
+
+[↑ back to top](#-ft_transcendence-ping-pong-website)
+
+---
+
+## 👥 Contributors
+
+
+| Member | Role | GitHub |
+|--------|------|--------|
+| 🟣 **Alena ** | Backend & Real-Time Lead (Fastify, User Mgmt, Sockets, Chat) | [@42Alena](https://github.com/42Alena) |
+| 🟢 **Sveva** | Game & Frontend Lead (Canvas, AI, Tailwind, Customization) | [@svevotti](https://github.com/svevotti) |
+| 🔵 **Luis** | **Database & Data Protection Lead** (SQLite schema & migrations, WAL/perf, data lifecycle, GDPR deletion/anonymization, observability & DB health) | [@Numbersdontlie](https://github.com/Numbersdontlie) |
+
+[↑ back to top](#-ft_transcendence-ping-pong-website)
+
+---
+
+## 📄 License
+
+MIT
+
+[↑ back to top](#-ft_transcendence-ping-pong-website)
+


### PR DESCRIPTION
Update project plan — replace 2FA, expand Luis’s responsibilities

Description:

Module change: replaced 2FA + JWT (major) with two minors (SQLite schema/init + GDPR/account deletion) → counts as one major.

Luis’s responsibilities updated: now Database & Data Protection Lead (SQLite migrations, WAL, schema health, GDPR delete/anonymize).

Team responsibilities clarified:

Alena → Backend & Real-Time (Fastify, User Mgmt, Remote Players, Live Chat).

Sveva → Game & Frontend (Canvas rendering, AI Opponent, Tailwind UI, Customization).

Luis → Database & GDPR (SQLite schema, backups, observability, GDPR endpoints).

README updated: modules table, team roles, evaluation checklist, navigation links.